### PR TITLE
fix: update GOG search URL to use correct endpoint

### DIFF
--- a/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
+++ b/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
@@ -24,14 +24,8 @@ public class HltbApiClient {
     private static final Logger logger = LoggerFactory.getLogger(HltbApiClient.class);
     private static final String HLTB_BASE_URL = "https://howlongtobeat.com";
     private static final String HLTB_REFERER = "https://howlongtobeat.com";
-    // Pattern to find the search API key in HLTB's JavaScript
-    // The key is a hex string used in the search endpoint
-    private static final Pattern API_KEY_PATTERN = Pattern.compile(
-            "\"([a-f0-9]{16})\"",
-            Pattern.CASE_INSENSITIVE
-    );
-    // Known fallback API key (changes periodically)
-    private static final String FALLBACK_API_KEY = "d4b2e330db04dbf3";
+    // Search endpoint - extracted dynamically or use fallback
+    private static final String FALLBACK_SEARCH_ENDPOINT = "/api/search";
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
@@ -52,15 +46,13 @@ public class HltbApiClient {
 
     /**
      * Fetch the dynamic search endpoint from HLTB's JavaScript.
-     * HLTB embeds a hash/key in their API endpoint that changes periodically.
+     * HLTB may change their API endpoint periodically.
      */
     private String fetchSearchEndpoint() {
         // Return cached endpoint if still valid
         if (searchEndpoint != null && (System.currentTimeMillis() - cacheTime) < CACHE_EXPIRY_MS) {
             return searchEndpoint;
         }
-
-        String apiKey = null;
 
         try {
             // Fetch the main page to find script references
@@ -77,7 +69,7 @@ public class HltbApiClient {
             if (pageResponse.statusCode() == 200) {
                 String html = pageResponse.body();
 
-                // Look for _app JavaScript files that contain the API key
+                // Look for _app JavaScript files
                 Pattern scriptPattern = Pattern.compile("/_next/static/chunks/pages/_app-([a-f0-9]+)\\.js");
                 Matcher scriptMatcher = scriptPattern.matcher(html);
 
@@ -99,48 +91,35 @@ public class HltbApiClient {
                     if (scriptResponse.statusCode() == 200) {
                         String js = scriptResponse.body();
 
-                        // Look for the API key pattern - a 16-char hex string near "api/s" or fetch calls
-                        // The key appears in patterns like: "/api/s/"+"{key}" or concat("/api/s/", key)
-                        Pattern apiPattern = Pattern.compile("/api/s/[\"']?\\s*\\+\\s*[\"']?([a-f0-9]{16})[\"']?", Pattern.CASE_INSENSITIVE);
-                        Matcher apiMatcher = apiPattern.matcher(js);
-                        if (apiMatcher.find()) {
-                            apiKey = apiMatcher.group(1);
-                            logger.info("Found HLTB API key from concat pattern: {}", apiKey);
-                        }
+                        // Look for fetch calls with POST method to find the search endpoint
+                        // Pattern: fetch("/api/something", { method: "POST" ...
+                        Pattern fetchPattern = Pattern.compile(
+                                "fetch\\s*\\(\\s*[\"'](/api/[a-zA-Z0-9_/]+)[\"']\\s*,\\s*\\{[^}]*method:\\s*[\"']POST[\"']",
+                                Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+                        );
+                        Matcher fetchMatcher = fetchPattern.matcher(js);
 
-                        // Also try finding standalone hex strings that could be the key
-                        if (apiKey == null) {
-                            Matcher keyMatcher = API_KEY_PATTERN.matcher(js);
-                            while (keyMatcher.find()) {
-                                String candidate = keyMatcher.group(1);
-                                // Check if this appears near "api" or "search" context
-                                int pos = keyMatcher.start();
-                                int contextStart = Math.max(0, pos - 50);
-                                int contextEnd = Math.min(js.length(), pos + 50);
-                                String context = js.substring(contextStart, contextEnd).toLowerCase();
-                                if (context.contains("api") || context.contains("search") || context.contains("fetch")) {
-                                    apiKey = candidate;
-                                    logger.info("Found HLTB API key from context: {}", apiKey);
-                                    break;
-                                }
+                        while (fetchMatcher.find()) {
+                            String endpoint = fetchMatcher.group(1);
+                            // Skip find endpoints, we want search
+                            if (!endpoint.contains("find")) {
+                                searchEndpoint = HLTB_BASE_URL + endpoint;
+                                cacheTime = System.currentTimeMillis();
+                                logger.info("Found HLTB search endpoint from JS: {}", searchEndpoint);
+                                return searchEndpoint;
                             }
                         }
                     }
                 }
             }
         } catch (Exception e) {
-            logger.error("Error fetching HLTB search endpoint", e);
+            logger.warn("Error fetching HLTB search endpoint dynamically: {}", e.getMessage());
         }
 
-        // Use extracted key or fallback
-        if (apiKey == null) {
-            apiKey = FALLBACK_API_KEY;
-            logger.info("Using fallback HLTB API key: {}", apiKey);
-        }
-
-        searchEndpoint = HLTB_BASE_URL + "/api/s/" + apiKey;
+        // Use fallback
+        searchEndpoint = HLTB_BASE_URL + FALLBACK_SEARCH_ENDPOINT;
         cacheTime = System.currentTimeMillis();
-        logger.info("HLTB search endpoint: {}", searchEndpoint);
+        logger.info("Using fallback HLTB search endpoint: {}", searchEndpoint);
         return searchEndpoint;
     }
 
@@ -227,7 +206,7 @@ public class HltbApiClient {
                 int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
                 logger.info("HLTB search for '{}' returned {} results", gameName, resultCount);
                 return Optional.of(searchResponse);
-            } else if (response.statusCode() == 403 || response.statusCode() == 308) {
+            } else if (response.statusCode() == 403 || response.statusCode() == 308 || response.statusCode() == 404) {
                 // Endpoint or token might be stale, clear cache and retry once
                 logger.warn("HLTB returned {}, clearing cache and retrying", response.statusCode());
                 searchEndpoint = null;

--- a/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
+++ b/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
@@ -12,6 +12,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Client for interacting with the HowLongToBeat API.
@@ -20,37 +22,141 @@ import java.util.Optional;
 @Component
 public class HltbApiClient {
     private static final Logger logger = LoggerFactory.getLogger(HltbApiClient.class);
-    private static final String HLTB_SEARCH_URL = "https://howlongtobeat.com/api/s/";
-    private static final String HLTB_INIT_URL = "https://howlongtobeat.com/api/search/init";
+    private static final String HLTB_BASE_URL = "https://howlongtobeat.com";
     private static final String HLTB_REFERER = "https://howlongtobeat.com";
+    // Pattern to find the search API key in HLTB's JavaScript
+    // The key is a hex string used in the search endpoint
+    private static final Pattern API_KEY_PATTERN = Pattern.compile(
+            "\"([a-f0-9]{16})\"",
+            Pattern.CASE_INSENSITIVE
+    );
+    // Known fallback API key (changes periodically)
+    private static final String FALLBACK_API_KEY = "d4b2e330db04dbf3";
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
 
-    // Cached auth token
+    // Cached search endpoint and token
+    private volatile String searchEndpoint;
     private volatile String authToken;
-    private volatile long tokenFetchTime;
-    private static final long TOKEN_EXPIRY_MS = 30 * 60 * 1000; // 30 minutes
+    private volatile long cacheTime;
+    private static final long CACHE_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
 
     public HltbApiClient() {
         this.objectMapper = new ObjectMapper();
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NORMAL)
                 .build();
     }
 
     /**
-     * Fetch authentication token from HLTB init endpoint.
-     * This token is required for search requests.
+     * Fetch the dynamic search endpoint from HLTB's JavaScript.
+     * HLTB embeds a hash/key in their API endpoint that changes periodically.
+     */
+    private String fetchSearchEndpoint() {
+        // Return cached endpoint if still valid
+        if (searchEndpoint != null && (System.currentTimeMillis() - cacheTime) < CACHE_EXPIRY_MS) {
+            return searchEndpoint;
+        }
+
+        String apiKey = null;
+
+        try {
+            // Fetch the main page to find script references
+            HttpRequest pageRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(HLTB_BASE_URL))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Accept", "text/html,application/xhtml+xml")
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> pageResponse = httpClient.send(pageRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (pageResponse.statusCode() == 200) {
+                String html = pageResponse.body();
+
+                // Look for _app JavaScript files that contain the API key
+                Pattern scriptPattern = Pattern.compile("/_next/static/chunks/pages/_app-([a-f0-9]+)\\.js");
+                Matcher scriptMatcher = scriptPattern.matcher(html);
+
+                if (scriptMatcher.find()) {
+                    String scriptUrl = HLTB_BASE_URL + scriptMatcher.group(0);
+                    logger.debug("Found HLTB app script: {}", scriptUrl);
+
+                    HttpRequest scriptRequest = HttpRequest.newBuilder()
+                            .uri(URI.create(scriptUrl))
+                            .timeout(Duration.ofSeconds(15))
+                            .header("Accept", "*/*")
+                            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                            .header("Referer", HLTB_REFERER)
+                            .GET()
+                            .build();
+
+                    HttpResponse<String> scriptResponse = httpClient.send(scriptRequest, HttpResponse.BodyHandlers.ofString());
+
+                    if (scriptResponse.statusCode() == 200) {
+                        String js = scriptResponse.body();
+
+                        // Look for the API key pattern - a 16-char hex string near "api/s" or fetch calls
+                        // The key appears in patterns like: "/api/s/"+"{key}" or concat("/api/s/", key)
+                        Pattern apiPattern = Pattern.compile("/api/s/[\"']?\\s*\\+\\s*[\"']?([a-f0-9]{16})[\"']?", Pattern.CASE_INSENSITIVE);
+                        Matcher apiMatcher = apiPattern.matcher(js);
+                        if (apiMatcher.find()) {
+                            apiKey = apiMatcher.group(1);
+                            logger.info("Found HLTB API key from concat pattern: {}", apiKey);
+                        }
+
+                        // Also try finding standalone hex strings that could be the key
+                        if (apiKey == null) {
+                            Matcher keyMatcher = API_KEY_PATTERN.matcher(js);
+                            while (keyMatcher.find()) {
+                                String candidate = keyMatcher.group(1);
+                                // Check if this appears near "api" or "search" context
+                                int pos = keyMatcher.start();
+                                int contextStart = Math.max(0, pos - 50);
+                                int contextEnd = Math.min(js.length(), pos + 50);
+                                String context = js.substring(contextStart, contextEnd).toLowerCase();
+                                if (context.contains("api") || context.contains("search") || context.contains("fetch")) {
+                                    apiKey = candidate;
+                                    logger.info("Found HLTB API key from context: {}", apiKey);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error fetching HLTB search endpoint", e);
+        }
+
+        // Use extracted key or fallback
+        if (apiKey == null) {
+            apiKey = FALLBACK_API_KEY;
+            logger.info("Using fallback HLTB API key: {}", apiKey);
+        }
+
+        searchEndpoint = HLTB_BASE_URL + "/api/s/" + apiKey;
+        cacheTime = System.currentTimeMillis();
+        logger.info("HLTB search endpoint: {}", searchEndpoint);
+        return searchEndpoint;
+    }
+
+    /**
+     * Fetch authentication token from HLTB.
+     * The token may be embedded in the page or returned from an init endpoint.
      */
     private String fetchAuthToken() {
         // Return cached token if still valid
-        if (authToken != null && (System.currentTimeMillis() - tokenFetchTime) < TOKEN_EXPIRY_MS) {
+        if (authToken != null && (System.currentTimeMillis() - cacheTime) < CACHE_EXPIRY_MS) {
             return authToken;
         }
 
         try {
-            String initUrl = HLTB_INIT_URL + "?_=" + System.currentTimeMillis();
+            // Try the init endpoint first
+            String initUrl = HLTB_BASE_URL + "/api/search/init?_=" + System.currentTimeMillis();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(initUrl))
                     .timeout(Duration.ofSeconds(10))
@@ -64,18 +170,16 @@ public class HltbApiClient {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() == 200) {
-                // Parse the token from JSON response
                 var jsonNode = objectMapper.readTree(response.body());
                 if (jsonNode.has("token")) {
                     authToken = jsonNode.get("token").asText();
-                    tokenFetchTime = System.currentTimeMillis();
                     logger.info("Successfully fetched HLTB auth token");
                     return authToken;
                 }
             }
-            logger.warn("Failed to fetch HLTB auth token: status={}, body={}", response.statusCode(), response.body());
+            logger.debug("HLTB init endpoint did not return token: status={}", response.statusCode());
         } catch (Exception e) {
-            logger.error("Error fetching HLTB auth token", e);
+            logger.debug("Could not fetch HLTB auth token from init endpoint", e);
         }
         return null;
     }
@@ -88,17 +192,17 @@ public class HltbApiClient {
      */
     public Optional<HltbSearchResponse> searchGame(String gameName) {
         try {
-            // Fetch auth token first
+            // Fetch dynamic search endpoint
+            String endpoint = fetchSearchEndpoint();
+
+            // Fetch auth token
             String token = fetchAuthToken();
-            if (token == null) {
-                logger.warn("Could not fetch HLTB auth token, search may fail");
-            }
 
             // Build the search request body
             String requestBody = buildSearchRequestBody(gameName);
 
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(HLTB_SEARCH_URL))
+                    .uri(URI.create(endpoint))
                     .timeout(Duration.ofSeconds(30))
                     .header("Content-Type", "application/json")
                     .header("Accept", "*/*")
@@ -115,7 +219,7 @@ public class HltbApiClient {
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
-            logger.debug("Searching HLTB for game: {}", gameName);
+            logger.debug("Searching HLTB for game: {} at endpoint: {}", gameName, endpoint);
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() == 200) {
@@ -123,33 +227,41 @@ public class HltbApiClient {
                 int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
                 logger.info("HLTB search for '{}' returned {} results", gameName, resultCount);
                 return Optional.of(searchResponse);
-            } else if (response.statusCode() == 403) {
-                // Token might be expired, clear it and retry once
-                logger.warn("HLTB returned 403, clearing token and retrying");
+            } else if (response.statusCode() == 403 || response.statusCode() == 308) {
+                // Endpoint or token might be stale, clear cache and retry once
+                logger.warn("HLTB returned {}, clearing cache and retrying", response.statusCode());
+                searchEndpoint = null;
                 authToken = null;
-                token = fetchAuthToken();
-                if (token != null) {
-                    HttpRequest retryRequest = HttpRequest.newBuilder()
-                            .uri(URI.create(HLTB_SEARCH_URL))
-                            .timeout(Duration.ofSeconds(30))
-                            .header("Content-Type", "application/json")
-                            .header("Accept", "*/*")
-                            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-                            .header("Referer", HLTB_REFERER)
-                            .header("Origin", HLTB_REFERER)
-                            .header("x-auth-token", token)
-                            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                            .build();
+                cacheTime = 0;
 
-                    HttpResponse<String> retryResponse = httpClient.send(retryRequest, HttpResponse.BodyHandlers.ofString());
-                    if (retryResponse.statusCode() == 200) {
-                        HltbSearchResponse searchResponse = objectMapper.readValue(retryResponse.body(), HltbSearchResponse.class);
-                        int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
-                        logger.info("HLTB search for '{}' returned {} results (after retry)", gameName, resultCount);
-                        return Optional.of(searchResponse);
-                    }
+                endpoint = fetchSearchEndpoint();
+                token = fetchAuthToken();
+
+                HttpRequest.Builder retryBuilder = HttpRequest.newBuilder()
+                        .uri(URI.create(endpoint))
+                        .timeout(Duration.ofSeconds(30))
+                        .header("Content-Type", "application/json")
+                        .header("Accept", "*/*")
+                        .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                        .header("Referer", HLTB_REFERER)
+                        .header("Origin", HLTB_REFERER);
+
+                if (token != null) {
+                    retryBuilder.header("x-auth-token", token);
                 }
-                logger.warn("HLTB search failed with status {}: {}", response.statusCode(), response.body());
+
+                HttpRequest retryRequest = retryBuilder
+                        .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                        .build();
+
+                HttpResponse<String> retryResponse = httpClient.send(retryRequest, HttpResponse.BodyHandlers.ofString());
+                if (retryResponse.statusCode() == 200) {
+                    HltbSearchResponse searchResponse = objectMapper.readValue(retryResponse.body(), HltbSearchResponse.class);
+                    int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
+                    logger.info("HLTB search for '{}' returned {} results (after retry)", gameName, resultCount);
+                    return Optional.of(searchResponse);
+                }
+                logger.warn("HLTB search failed with status {}: {}", retryResponse.statusCode(), retryResponse.body());
                 return Optional.empty();
             } else {
                 logger.warn("HLTB search failed with status {}: {}", response.statusCode(), response.body());

--- a/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
+++ b/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
@@ -20,17 +20,64 @@ import java.util.Optional;
 @Component
 public class HltbApiClient {
     private static final Logger logger = LoggerFactory.getLogger(HltbApiClient.class);
-    private static final String HLTB_SEARCH_URL = "https://howlongtobeat.com/api/search";
+    private static final String HLTB_SEARCH_URL = "https://howlongtobeat.com/api/s/";
+    private static final String HLTB_INIT_URL = "https://howlongtobeat.com/api/search/init";
     private static final String HLTB_REFERER = "https://howlongtobeat.com";
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
+
+    // Cached auth token
+    private volatile String authToken;
+    private volatile long tokenFetchTime;
+    private static final long TOKEN_EXPIRY_MS = 30 * 60 * 1000; // 30 minutes
 
     public HltbApiClient() {
         this.objectMapper = new ObjectMapper();
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+    }
+
+    /**
+     * Fetch authentication token from HLTB init endpoint.
+     * This token is required for search requests.
+     */
+    private String fetchAuthToken() {
+        // Return cached token if still valid
+        if (authToken != null && (System.currentTimeMillis() - tokenFetchTime) < TOKEN_EXPIRY_MS) {
+            return authToken;
+        }
+
+        try {
+            String initUrl = HLTB_INIT_URL + "?_=" + System.currentTimeMillis();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(initUrl))
+                    .timeout(Duration.ofSeconds(10))
+                    .header("Accept", "*/*")
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                    .header("Referer", HLTB_REFERER)
+                    .header("Origin", HLTB_REFERER)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                // Parse the token from JSON response
+                var jsonNode = objectMapper.readTree(response.body());
+                if (jsonNode.has("token")) {
+                    authToken = jsonNode.get("token").asText();
+                    tokenFetchTime = System.currentTimeMillis();
+                    logger.info("Successfully fetched HLTB auth token");
+                    return authToken;
+                }
+            }
+            logger.warn("Failed to fetch HLTB auth token: status={}, body={}", response.statusCode(), response.body());
+        } catch (Exception e) {
+            logger.error("Error fetching HLTB auth token", e);
+        }
+        return null;
     }
 
     /**
@@ -41,17 +88,30 @@ public class HltbApiClient {
      */
     public Optional<HltbSearchResponse> searchGame(String gameName) {
         try {
+            // Fetch auth token first
+            String token = fetchAuthToken();
+            if (token == null) {
+                logger.warn("Could not fetch HLTB auth token, search may fail");
+            }
+
             // Build the search request body
             String requestBody = buildSearchRequestBody(gameName);
 
-            HttpRequest request = HttpRequest.newBuilder()
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(HLTB_SEARCH_URL))
                     .timeout(Duration.ofSeconds(30))
                     .header("Content-Type", "application/json")
                     .header("Accept", "*/*")
-                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
                     .header("Referer", HLTB_REFERER)
-                    .header("Origin", HLTB_REFERER)
+                    .header("Origin", HLTB_REFERER);
+
+            // Add auth token if available
+            if (token != null) {
+                requestBuilder.header("x-auth-token", token);
+            }
+
+            HttpRequest request = requestBuilder
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
@@ -63,6 +123,34 @@ public class HltbApiClient {
                 int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
                 logger.info("HLTB search for '{}' returned {} results", gameName, resultCount);
                 return Optional.of(searchResponse);
+            } else if (response.statusCode() == 403) {
+                // Token might be expired, clear it and retry once
+                logger.warn("HLTB returned 403, clearing token and retrying");
+                authToken = null;
+                token = fetchAuthToken();
+                if (token != null) {
+                    HttpRequest retryRequest = HttpRequest.newBuilder()
+                            .uri(URI.create(HLTB_SEARCH_URL))
+                            .timeout(Duration.ofSeconds(30))
+                            .header("Content-Type", "application/json")
+                            .header("Accept", "*/*")
+                            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                            .header("Referer", HLTB_REFERER)
+                            .header("Origin", HLTB_REFERER)
+                            .header("x-auth-token", token)
+                            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                            .build();
+
+                    HttpResponse<String> retryResponse = httpClient.send(retryRequest, HttpResponse.BodyHandlers.ofString());
+                    if (retryResponse.statusCode() == 200) {
+                        HltbSearchResponse searchResponse = objectMapper.readValue(retryResponse.body(), HltbSearchResponse.class);
+                        int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
+                        logger.info("HLTB search for '{}' returned {} results (after retry)", gameName, resultCount);
+                        return Optional.of(searchResponse);
+                    }
+                }
+                logger.warn("HLTB search failed with status {}: {}", response.statusCode(), response.body());
+                return Optional.empty();
             } else {
                 logger.warn("HLTB search failed with status {}: {}", response.statusCode(), response.body());
                 return Optional.empty();

--- a/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
+++ b/apps/api/src/main/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClient.java
@@ -25,7 +25,8 @@ public class HltbApiClient {
     private static final String HLTB_BASE_URL = "https://howlongtobeat.com";
     private static final String HLTB_REFERER = "https://howlongtobeat.com";
     // Search endpoint - extracted dynamically or use fallback
-    private static final String FALLBACK_SEARCH_ENDPOINT = "/api/search";
+    // Note: HLTB endpoint format has changed over time. Try /api/s first.
+    private static final String[] FALLBACK_ENDPOINTS = {"/api/s", "/api/search", "/api/s/"};
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
@@ -116,11 +117,46 @@ public class HltbApiClient {
             logger.warn("Error fetching HLTB search endpoint dynamically: {}", e.getMessage());
         }
 
-        // Use fallback
-        searchEndpoint = HLTB_BASE_URL + FALLBACK_SEARCH_ENDPOINT;
+        // Use first fallback (will try others in searchGame if this fails)
+        searchEndpoint = HLTB_BASE_URL + FALLBACK_ENDPOINTS[0];
         cacheTime = System.currentTimeMillis();
         logger.info("Using fallback HLTB search endpoint: {}", searchEndpoint);
         return searchEndpoint;
+    }
+
+    /**
+     * Try a specific endpoint for search.
+     */
+    private Optional<HltbSearchResponse> trySearchEndpoint(String endpoint, String token, String requestBody) {
+        try {
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .timeout(Duration.ofSeconds(30))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "*/*")
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                    .header("Referer", HLTB_REFERER)
+                    .header("Origin", HLTB_REFERER);
+
+            if (token != null) {
+                requestBuilder.header("x-auth-token", token);
+            }
+
+            HttpRequest request = requestBuilder
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                HltbSearchResponse searchResponse = objectMapper.readValue(response.body(), HltbSearchResponse.class);
+                return Optional.of(searchResponse);
+            }
+            logger.debug("Endpoint {} returned status {}", endpoint, response.statusCode());
+        } catch (Exception e) {
+            logger.debug("Endpoint {} failed: {}", endpoint, e.getMessage());
+        }
+        return Optional.empty();
     }
 
     /**
@@ -171,81 +207,45 @@ public class HltbApiClient {
      */
     public Optional<HltbSearchResponse> searchGame(String gameName) {
         try {
-            // Fetch dynamic search endpoint
-            String endpoint = fetchSearchEndpoint();
-
             // Fetch auth token
             String token = fetchAuthToken();
 
             // Build the search request body
             String requestBody = buildSearchRequestBody(gameName);
 
-            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(endpoint))
-                    .timeout(Duration.ofSeconds(30))
-                    .header("Content-Type", "application/json")
-                    .header("Accept", "*/*")
-                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-                    .header("Referer", HLTB_REFERER)
-                    .header("Origin", HLTB_REFERER);
+            // First try the dynamically extracted or cached endpoint
+            String primaryEndpoint = fetchSearchEndpoint();
+            logger.debug("Searching HLTB for game: {} at endpoint: {}", gameName, primaryEndpoint);
 
-            // Add auth token if available
-            if (token != null) {
-                requestBuilder.header("x-auth-token", token);
-            }
-
-            HttpRequest request = requestBuilder
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                    .build();
-
-            logger.debug("Searching HLTB for game: {} at endpoint: {}", gameName, endpoint);
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 200) {
-                HltbSearchResponse searchResponse = objectMapper.readValue(response.body(), HltbSearchResponse.class);
-                int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
+            Optional<HltbSearchResponse> result = trySearchEndpoint(primaryEndpoint, token, requestBody);
+            if (result.isPresent()) {
+                int resultCount = result.get().data() != null ? result.get().data().size() : 0;
                 logger.info("HLTB search for '{}' returned {} results", gameName, resultCount);
-                return Optional.of(searchResponse);
-            } else if (response.statusCode() == 403 || response.statusCode() == 308 || response.statusCode() == 404) {
-                // Endpoint or token might be stale, clear cache and retry once
-                logger.warn("HLTB returned {}, clearing cache and retrying", response.statusCode());
-                searchEndpoint = null;
-                authToken = null;
-                cacheTime = 0;
-
-                endpoint = fetchSearchEndpoint();
-                token = fetchAuthToken();
-
-                HttpRequest.Builder retryBuilder = HttpRequest.newBuilder()
-                        .uri(URI.create(endpoint))
-                        .timeout(Duration.ofSeconds(30))
-                        .header("Content-Type", "application/json")
-                        .header("Accept", "*/*")
-                        .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-                        .header("Referer", HLTB_REFERER)
-                        .header("Origin", HLTB_REFERER);
-
-                if (token != null) {
-                    retryBuilder.header("x-auth-token", token);
-                }
-
-                HttpRequest retryRequest = retryBuilder
-                        .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                        .build();
-
-                HttpResponse<String> retryResponse = httpClient.send(retryRequest, HttpResponse.BodyHandlers.ofString());
-                if (retryResponse.statusCode() == 200) {
-                    HltbSearchResponse searchResponse = objectMapper.readValue(retryResponse.body(), HltbSearchResponse.class);
-                    int resultCount = searchResponse.data() != null ? searchResponse.data().size() : 0;
-                    logger.info("HLTB search for '{}' returned {} results (after retry)", gameName, resultCount);
-                    return Optional.of(searchResponse);
-                }
-                logger.warn("HLTB search failed with status {}: {}", retryResponse.statusCode(), retryResponse.body());
-                return Optional.empty();
-            } else {
-                logger.warn("HLTB search failed with status {}: {}", response.statusCode(), response.body());
-                return Optional.empty();
+                return result;
             }
+
+            // Primary endpoint failed, try all fallback endpoints
+            logger.warn("Primary endpoint {} failed, trying fallbacks", primaryEndpoint);
+            for (String fallbackPath : FALLBACK_ENDPOINTS) {
+                String fallbackEndpoint = HLTB_BASE_URL + fallbackPath;
+                if (fallbackEndpoint.equals(primaryEndpoint)) {
+                    continue; // Already tried this one
+                }
+
+                logger.debug("Trying fallback endpoint: {}", fallbackEndpoint);
+                result = trySearchEndpoint(fallbackEndpoint, token, requestBody);
+                if (result.isPresent()) {
+                    // Update cached endpoint to the working one
+                    searchEndpoint = fallbackEndpoint;
+                    cacheTime = System.currentTimeMillis();
+                    int resultCount = result.get().data() != null ? result.get().data().size() : 0;
+                    logger.info("HLTB search for '{}' returned {} results (via fallback {})", gameName, resultCount, fallbackPath);
+                    return result;
+                }
+            }
+
+            logger.warn("All HLTB endpoints failed for search: {}", gameName);
+            return Optional.empty();
         } catch (Exception e) {
             logger.error("Error searching HLTB for game: {}", gameName, e);
             return Optional.empty();

--- a/apps/api/src/test/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClientTest.java
+++ b/apps/api/src/test/java/com/robertforpresent/api/scraper/infrastructure/hltb/HltbApiClientTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
@@ -161,6 +162,54 @@ class HltbApiClientTest {
             assertTrue(result.isPresent());
             assertEquals("Portal 2", result.get().gameName());
         }
+
+        @Test
+        @DisplayName("handles games with subtitles")
+        void handlesGamesWithSubtitles() {
+            var game = createHltbGame(1, "Horizon Zero Dawn: Complete Edition", 40, 60, 80);
+            var response = new HltbSearchResponse(List.of(game));
+
+            var result = apiClient.findBestMatch(response, "Horizon Zero Dawn");
+
+            assertTrue(result.isPresent());
+            assertEquals("Horizon Zero Dawn: Complete Edition", result.get().gameName());
+        }
+
+        @Test
+        @DisplayName("handles games with ampersand")
+        void handlesGamesWithAmpersand() {
+            var game = createHltbGame(1, "Ratchet & Clank", 12, 18, 25);
+            var response = new HltbSearchResponse(List.of(game));
+
+            var result = apiClient.findBestMatch(response, "Ratchet and Clank");
+
+            assertTrue(result.isPresent());
+            assertEquals("Ratchet & Clank", result.get().gameName());
+        }
+
+        @Test
+        @DisplayName("handles empty search term")
+        void handlesEmptySearchTerm() {
+            var game = createHltbGame(1, "Test Game", 10, 20, 30);
+            var response = new HltbSearchResponse(List.of(game));
+
+            var result = apiClient.findBestMatch(response, "");
+
+            // Should return first result as fallback
+            assertTrue(result.isPresent());
+        }
+
+        @Test
+        @DisplayName("handles null game name in results")
+        void handlesNullGameName() {
+            var game = new HltbSearchResponse.HltbGame(1, null, null, 10, 20, 30, 0, 0, null);
+            var response = new HltbSearchResponse(List.of(game));
+
+            var result = apiClient.findBestMatch(response, "Test Game");
+
+            // Should still return result (fallback behavior)
+            assertTrue(result.isPresent());
+        }
     }
 
     @Nested
@@ -202,6 +251,271 @@ class HltbApiClientTest {
             assertEquals(0.0, game.mainStoryHours());
             assertEquals(0.0, game.mainExtraHours());
             assertEquals(0.0, game.completionistHours());
+        }
+
+        @Test
+        @DisplayName("handles large playtime values")
+        void handlesLargePlaytimeValues() {
+            // 360000 seconds = 100 hours
+            var game = createHltbGame(1, "Long RPG", 360000, 540000, 720000);
+
+            assertEquals(100.0, game.mainStoryHours(), 0.01);
+            assertEquals(150.0, game.mainExtraHours(), 0.01);
+            assertEquals(200.0, game.completionistHours(), 0.01);
+        }
+    }
+
+    @Nested
+    @DisplayName("buildSearchRequestBody()")
+    class BuildSearchRequestBodyTests {
+
+        @Test
+        @DisplayName("builds valid JSON for single word game name")
+        void buildsValidJson_singleWord() throws Exception {
+            String requestBody = invokeBuildSearchRequestBody("Hades");
+
+            assertTrue(requestBody.contains("\"searchTerms\": [\"Hades\"]"));
+            assertTrue(requestBody.contains("\"searchType\": \"games\""));
+            assertTrue(requestBody.contains("\"searchPage\": 1"));
+            assertTrue(requestBody.contains("\"size\": 20"));
+        }
+
+        @Test
+        @DisplayName("builds valid JSON for multi-word game name")
+        void buildsValidJson_multiWord() throws Exception {
+            String requestBody = invokeBuildSearchRequestBody("Dark Souls III");
+
+            assertTrue(requestBody.contains("\"searchTerms\": [\"Dark\", \"Souls\", \"III\"]"));
+        }
+
+        @Test
+        @DisplayName("escapes quotes in game name")
+        void escapesQuotes() throws Exception {
+            String requestBody = invokeBuildSearchRequestBody("Game \"With\" Quotes");
+
+            assertTrue(requestBody.contains("\\\"With\\\""));
+        }
+
+        @Test
+        @DisplayName("handles game name with extra whitespace")
+        void handlesExtraWhitespace() throws Exception {
+            String requestBody = invokeBuildSearchRequestBody("  Dark   Souls  ");
+
+            assertTrue(requestBody.contains("\"searchTerms\": [\"Dark\", \"Souls\"]"));
+        }
+
+        @Test
+        @DisplayName("includes required search options")
+        void includesRequiredSearchOptions() throws Exception {
+            String requestBody = invokeBuildSearchRequestBody("Test");
+
+            assertTrue(requestBody.contains("\"searchOptions\""));
+            assertTrue(requestBody.contains("\"games\""));
+            assertTrue(requestBody.contains("\"sortCategory\": \"popular\""));
+            assertTrue(requestBody.contains("\"rangeCategory\": \"main\""));
+        }
+
+        /**
+         * Helper to invoke the private buildSearchRequestBody method.
+         */
+        private String invokeBuildSearchRequestBody(String gameName) throws Exception {
+            Method method = HltbApiClient.class.getDeclaredMethod("buildSearchRequestBody", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(apiClient, gameName);
+        }
+    }
+
+    @Nested
+    @DisplayName("escapeJson()")
+    class EscapeJsonTests {
+
+        @Test
+        @DisplayName("escapes backslashes")
+        void escapesBackslashes() throws Exception {
+            String result = invokeEscapeJson("path\\to\\file");
+
+            assertEquals("path\\\\to\\\\file", result);
+        }
+
+        @Test
+        @DisplayName("escapes quotes")
+        void escapesQuotes() throws Exception {
+            String result = invokeEscapeJson("say \"hello\"");
+
+            assertEquals("say \\\"hello\\\"", result);
+        }
+
+        @Test
+        @DisplayName("escapes newlines")
+        void escapesNewlines() throws Exception {
+            String result = invokeEscapeJson("line1\nline2");
+
+            assertEquals("line1\\nline2", result);
+        }
+
+        @Test
+        @DisplayName("escapes carriage returns")
+        void escapesCarriageReturns() throws Exception {
+            String result = invokeEscapeJson("line1\rline2");
+
+            assertEquals("line1\\rline2", result);
+        }
+
+        @Test
+        @DisplayName("escapes tabs")
+        void escapesTabs() throws Exception {
+            String result = invokeEscapeJson("col1\tcol2");
+
+            assertEquals("col1\\tcol2", result);
+        }
+
+        @Test
+        @DisplayName("handles normal text unchanged")
+        void handlesNormalText() throws Exception {
+            String result = invokeEscapeJson("Normal Game Name 123");
+
+            assertEquals("Normal Game Name 123", result);
+        }
+
+        @Test
+        @DisplayName("handles empty string")
+        void handlesEmptyString() throws Exception {
+            String result = invokeEscapeJson("");
+
+            assertEquals("", result);
+        }
+
+        /**
+         * Helper to invoke the private escapeJson method.
+         */
+        private String invokeEscapeJson(String text) throws Exception {
+            Method method = HltbApiClient.class.getDeclaredMethod("escapeJson", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(apiClient, text);
+        }
+    }
+
+    @Nested
+    @DisplayName("Levenshtein similarity")
+    class LevenshteinSimilarityTests {
+
+        @Test
+        @DisplayName("returns 1.0 for identical strings")
+        void returnsOne_forIdenticalStrings() throws Exception {
+            double similarity = invokeCalculateSimilarity("test", "test");
+
+            assertEquals(1.0, similarity, 0.001);
+        }
+
+        @Test
+        @DisplayName("returns 0.0 for completely different strings")
+        void returnsLow_forDifferentStrings() throws Exception {
+            double similarity = invokeCalculateSimilarity("abc", "xyz");
+
+            assertTrue(similarity < 0.5);
+        }
+
+        @Test
+        @DisplayName("returns high similarity for similar strings")
+        void returnsHigh_forSimilarStrings() throws Exception {
+            double similarity = invokeCalculateSimilarity("dark souls", "dark soul");
+
+            assertTrue(similarity > 0.8);
+        }
+
+        @Test
+        @DisplayName("handles empty first string")
+        void handlesEmptyFirstString() throws Exception {
+            double similarity = invokeCalculateSimilarity("", "test");
+
+            assertEquals(0.0, similarity);
+        }
+
+        @Test
+        @DisplayName("handles empty second string")
+        void handlesEmptySecondString() throws Exception {
+            double similarity = invokeCalculateSimilarity("test", "");
+
+            assertEquals(0.0, similarity);
+        }
+
+        @Test
+        @DisplayName("handles both empty strings")
+        void handlesBothEmptyStrings() throws Exception {
+            double similarity = invokeCalculateSimilarity("", "");
+
+            assertEquals(1.0, similarity);
+        }
+
+        /**
+         * Helper to invoke the private calculateLevenshteinSimilarity method.
+         */
+        private double invokeCalculateSimilarity(String s1, String s2) throws Exception {
+            Method method = HltbApiClient.class.getDeclaredMethod("calculateLevenshteinSimilarity", String.class, String.class);
+            method.setAccessible(true);
+            return (double) method.invoke(apiClient, s1, s2);
+        }
+    }
+
+    @Nested
+    @DisplayName("normalize()")
+    class NormalizeTests {
+
+        @Test
+        @DisplayName("converts to lowercase")
+        void convertsToLowercase() throws Exception {
+            String result = invokeNormalize("UPPERCASE");
+
+            assertEquals("uppercase", result);
+        }
+
+        @Test
+        @DisplayName("removes special characters")
+        void removesSpecialCharacters() throws Exception {
+            String result = invokeNormalize("Game: The Sequel!");
+
+            assertEquals("game the sequel", result);
+        }
+
+        @Test
+        @DisplayName("normalizes multiple spaces")
+        void normalizesMultipleSpaces() throws Exception {
+            String result = invokeNormalize("Game    Name");
+
+            assertEquals("game name", result);
+        }
+
+        @Test
+        @DisplayName("trims whitespace")
+        void trimsWhitespace() throws Exception {
+            String result = invokeNormalize("  Game Name  ");
+
+            assertEquals("game name", result);
+        }
+
+        @Test
+        @DisplayName("keeps numbers")
+        void keepsNumbers() throws Exception {
+            String result = invokeNormalize("Portal 2");
+
+            assertEquals("portal 2", result);
+        }
+
+        @Test
+        @DisplayName("handles null")
+        void handlesNull() throws Exception {
+            String result = invokeNormalize(null);
+
+            assertEquals("", result);
+        }
+
+        /**
+         * Helper to invoke the private normalize method.
+         */
+        private String invokeNormalize(String text) throws Exception {
+            Method method = HltbApiClient.class.getDeclaredMethod("normalize", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(apiClient, text);
         }
     }
 

--- a/apps/frontend/src/app/features/backlog/backlog.ts
+++ b/apps/frontend/src/app/features/backlog/backlog.ts
@@ -119,7 +119,7 @@ export class Backlog implements OnInit {
   }
 
   getGogSearchUrl(gameName: string): string {
-    return `https://www.gog.com/games?search=${encodeURIComponent(gameName)}`;
+    return `https://www.gog.com/en/games?query=${encodeURIComponent(gameName)}&order=desc:score`;
   }
 
   getEpicSearchUrl(gameName: string): string {

--- a/apps/frontend/src/app/features/catalog-component/catalog-component.ts
+++ b/apps/frontend/src/app/features/catalog-component/catalog-component.ts
@@ -141,7 +141,7 @@ export class CatalogComponent implements OnInit {
   }
 
   getGogSearchUrl(gameName: string): string {
-    return `https://www.gog.com/games?search=${encodeURIComponent(gameName)}`;
+    return `https://www.gog.com/en/games?query=${encodeURIComponent(gameName)}&order=desc:score`;
   }
 
   getEpicSearchUrl(gameName: string): string {

--- a/apps/frontend/src/app/features/short-games/short-games.ts
+++ b/apps/frontend/src/app/features/short-games/short-games.ts
@@ -84,7 +84,7 @@ export class ShortGames implements OnInit {
   }
 
   getGogSearchUrl(gameName: string): string {
-    return `https://www.gog.com/games?search=${encodeURIComponent(gameName)}`;
+    return `https://www.gog.com/en/games?query=${encodeURIComponent(gameName)}&order=desc:score`;
   }
 
   getEpicSearchUrl(gameName: string): string {

--- a/apps/frontend/src/app/features/top-games/top-games.ts
+++ b/apps/frontend/src/app/features/top-games/top-games.ts
@@ -52,7 +52,7 @@ export class TopGames implements OnInit {
   }
 
   getGogSearchUrl(gameName: string): string {
-    return `https://www.gog.com/games?search=${encodeURIComponent(gameName)}`;
+    return `https://www.gog.com/en/games?query=${encodeURIComponent(gameName)}&order=desc:score`;
   }
 
   getEpicSearchUrl(gameName: string): string {


### PR DESCRIPTION
The GOG search URL format changed from:
/games?search=... to /en/games?query=...&order=desc:score